### PR TITLE
fix: sanitize filepath names

### DIFF
--- a/unzip.go
+++ b/unzip.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"time"
+	"strings"
+	"fmt"
 )
 
 var (
@@ -120,6 +122,9 @@ func (uz Unzip) Extract() error {
 		}()
 
 		path := filepath.Join(uz.Dest, f.Name)
+		if !strings.HasPrefix(path, filepath.Clean(uz.Dest)+string(os.PathSeparator)) {
+            return fmt.Errorf("%s: illegal file path", path)
+        }
 
 		if f.FileInfo().IsDir() {
 			os.MkdirAll(path, f.Mode())


### PR DESCRIPTION
Prevent ZIP traversal by checking filepath names (https://github.com/snyk/zip-slip-vulnerability)

PoC to Test
```
package main
import ("./unzip"
"fmt")

func main() {
// zip file can be taken from here: https://github.com/snyk/zip-slip-vulnerability/tree/master/archives
u := unzip.New("/home/snoopy/ziptest/poc/ziptest.zip", "/home/snoopy/zipper/uploads")
err := u.Extract()
if err != nil {
fmt.Println(err)
}
}


```